### PR TITLE
Add !Sub to Sequence type

### DIFF
--- a/tags.json
+++ b/tags.json
@@ -11,7 +11,8 @@
     "Join",
     "Not",
     "Or",
-    "Select"
+    "Select",
+    "Sub"
   ],
   "scalar": [
     "Ref",

--- a/test.yml
+++ b/test.yml
@@ -10,3 +10,14 @@ InstanceId:
           #!/bin/bash -xe
           cfn-init -v --stack ${AWS::StackName} --resource Box --region ${AWS::Region}
           cfn-signal -e 0 --stack ${AWS::StackName} --resource Box --region ${AWS::Region}
+
+Outputs:
+  Output1:
+    Description: "Some quoted string"
+    Value: !Sub
+      - Instance ID is ${SomeVar}
+      - {SomeVar: !Ref InstanceId}
+
+  Output2:
+    Description: Some unquoted string
+    Value: !Sub Instance ID is ${InstanceId}


### PR DESCRIPTION
This allows for !Sub Mappings as shown http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-sub.html

Now allowing for two different type for the !Sub shorthand

` Value: !Sub Instance ID is ${InstanceId}`

and

```
 Value: !Sub
      - Instance ID is ${SomeVar}
      - {SomeVar: !Ref InstanceId}
```

This PR is for issue #1