### PR TITLE
Use Strict

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const yaml = require('js-yaml');
 const localTags = require('./tags.json');
 


### PR DESCRIPTION
When requiring this package on older Node versions (ex. 4.2.6) the following error is thrown on the line of inclusion. This is due to older versions of node not supporting function definitions unless the file is in strict mode. 

```
uncaughtException: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode
```

Without strict mode, this can break dependant packages if users are using an older node version.

This PR adds strict mode to the index.js file, which is included by dependant packages to use the functionality of this package.
