### PR TITLE
travis-ci remove jq requirement until it can be scoped for releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
-addons:
-  apt:
-    packages:
-      - jq
+# addons:
+#   apt:
+#     packages:
+#       - jq
 language: node_js
 node_js:
   - node
 script:
-  - npm run sort-tags.json
+  # - npm run sort-tags.json
   - npm test
 deploy:
   - provider: releases


### PR DESCRIPTION
comment out jq and sort tags requirement in travis.yml until it can be configured to sort only on releases